### PR TITLE
Use log4j2 for logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,9 +46,9 @@ libraryDependencies ++= Seq(
   "com.github.tomakehurst" % "wiremock" % "2.27.2" % Test,
 
   // logging
-  "org.slf4j" % "slf4j-api" % "1.7.32",
-  "org.slf4j" % "slf4j-log4j12" % "1.7.32",
-  "org.apache.logging.log4j" % "log4j" % "2.17.1",
+  "org.slf4j" % "slf4j-api" % "1.7.36",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.2",
+  "org.apache.logging.log4j" % "log4j" % "2.17.2",
 
   // config
   "com.typesafe" % "config" % "1.3.3",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,10 @@
+status = warn
+name = KafkaSecurityManagerLogConfig
+
+appender.console.type = Console
+appender.console.name = consoleAppender
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d] %p %m (%c)%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleAppender


### PR DESCRIPTION
Use the new log4j2 slf4j binding to make sure that log4j2 is used.
Please be aware that this could be a potential breaking change for users who supplied a custom log4 configuration.
This users must update their log4j configuration to be compatible with log4j2

This fixes #117 
